### PR TITLE
Bundler 2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ before_install: gem install bundler -v 2.0.1
 bundler_args: --without tools
 script: "bundle exec rake ci"
 rvm:
-  - 2.0.0
-  - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.4
-  - 2.5.1
+  - 2.4.6
+  - 2.5.5
   - ruby-head
   - jruby-9.1.5.0
   - jruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: ruby
 sudo: false
-before_install: gem install bundler -v 1.14.6
+before_install: gem install bundler -v 2.0.1
 bundler_args: --without tools
 script: "bundle exec rake ci"
 rvm:

--- a/tty-tree.gemspec
+++ b/tty-tree.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
### Describe the change
Updates bundler to 2.0.1

### Why are we doing this?
I was unable to install development dependencies under 2.0.1, so here's an update

### Benefits
- Updates to the latest and greatest bundler

### Drawbacks
- Drops support for Ruby 2.3 and earlier (they reached EoL anyway)

### Requirements
Put an X between brackets on each line if you have done the item:
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentaion updated?
