### PR TITLE
strip null bytes from pathname

### DIFF
--- a/lib/tty/tree/node.rb
+++ b/lib/tty/tree/node.rb
@@ -33,7 +33,12 @@ module TTY
                      :symlink?, :socket?, :pipe?
 
       def initialize(path, parent, prefix, level)
-        @path   = Pathname.new(path)
+        if path.is_a? String
+          # strip null bytes from the string to avoid throwing errors
+          path = path.delete("\0")
+        end
+
+        @path = Pathname.new(path)
         @name   = @path.basename
         @parent = Pathname.new(parent)
         @prefix = prefix
@@ -42,6 +47,7 @@ module TTY
 
       def full_path
         return parent if name.to_s.empty?
+
         parent.join(name)
       end
 

--- a/spec/unit/node_spec.rb
+++ b/spec/unit/node_spec.rb
@@ -4,7 +4,7 @@
 RSpec.describe TTY::Tree::Node do
   it "provides directory stats" do
     dir = fixtures_path('dir1')
-    node = TTY::Tree::Node.new(dir, '', '',  0)
+    node = TTY::Tree::Node.new(dir, '', '', 0)
 
     expect(node.directory?).to eq(true)
     expect(node.file?).to eq(false)
@@ -32,5 +32,11 @@ RSpec.describe TTY::Tree::Node do
     node_b = TTY::Tree::Node.new('dir2', '', '', 0)
 
     expect(node_a).to_not eq(node_b)
+  end
+
+  it "strips null bytes from pathname" do
+    node = nil
+    expect {node = TTY::Tree::Node.new("dir1\0", '', '', 0)}.not_to raise_error
+    expect(node.path.to_s).to eq('dir1')
   end
 end


### PR DESCRIPTION
### Describe the change
Strips null bytes from path names

### Why are we doing this?
In stympy/faker, we were getting null byte errors during our CI tests, with the errors raised from within tty-tree. This is hopefully a patch to fix these issues

### Benefits
- Allows tty-tree to gracefully handle null bytes in path names

### Requirements
Put an X between brackets on each line if you have done the item:
- [X] Tests written & passing locally?
- [X] Code style checked?
- [X] Rebased with `master` branch?
- [X] Documentaion updated?
