### PR TITLE
Include dirs on last level

### DIFF
--- a/lib/tty/tree/path_walker.rb
+++ b/lib/tty/tree/path_walker.rb
@@ -87,13 +87,15 @@ module TTY
             node = last_path_index == i ? LeafNode : Node
 
             if path.directory?
-              next if @level != -1 && level + 1 > @level
+              next if @level != -1 && level > @level
 
               @nodes << node.new(sub_path, parent_path, prefix, level)
               @dirs_count += 1
 
               postfix = ':pipe'
               postfix = ':space' if i == last_path_index
+
+              next if @level != -1 && level + 1 > @level
 
               walk(path, path.children, prefix + postfix, level + 1)
             elsif path.file?

--- a/spec/unit/path_walker_spec.rb
+++ b/spec/unit/path_walker_spec.rb
@@ -71,6 +71,7 @@ RSpec.describe TTY::Tree::PathWalker do
       "dir1",
       "dir1/config.dat",
       "dir1/dir2",
+      "dir1/dir2/dir3",
       "dir1/dir2/file2-1.txt",
       "dir1/file1-1.txt",
       "dir1/file1-2.txt",

--- a/spec/unit/path_walker_spec.rb
+++ b/spec/unit/path_walker_spec.rb
@@ -114,7 +114,8 @@ RSpec.describe TTY::Tree::PathWalker do
 
     expect(walker.files_count).to eq(4)
 
-    expect(walker.dirs_count).to eq(1)
+    expect(walker.dirs_count).to eq(2)
+
   end
 
   it "raises when walking non-directory" do


### PR DESCRIPTION
### Describe the change
This PR adjusts how directory depth is evaluated when walking paths. Specifically, it modifies the condition that skips directories based on depth, allowing directories at the maximum specified depth (`@level`) to be included in the output.

**Before**
```
dir1
├── config.dat
├── dir2
│   └── file2-1.txt
├── file1-1.txt
└── file1-2.txt
```
**After**
```
dir1
├── config.dat
├── dir2
│   ├── dir3
│   └── file2-1.txt
├── file1-1.txt
└── file1-2.txt
```

### Why are we doing this?
Previously, directories at the last level were excluded when a maximum depth was set, even though they may contain relevant content. This change ensures that all directories up to and including the final level are included, aligning with expected behavior when using a depth limit. This solves issue #6.

### Benefits
Users will now see the full structure of a tree up to the specified depth, including directories at the final level. This offers more complete visibility into the directory structure and improves the utility of the tree output.

### Drawbacks
This change increases the number of nodes returned in some cases, particularly for trees walked with a depth limit. As a result, output may differ from previous behavior, which could affect downstream uses relying on the older node count or structure.

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentation updated?
- [ ] Changelog updated?
